### PR TITLE
chore: update publish workflow secrets

### DIFF
--- a/.github/workflows/call-publish.yml
+++ b/.github/workflows/call-publish.yml
@@ -1,0 +1,16 @@
+name: Call Publish Workflow
+
+on:
+  push:
+    branches:
+      - main  # Runs only on push (merge) to main
+
+jobs:
+  call-publish:
+    uses: splunk-soar-connectors/.github/.github/workflows/publish.yml@main
+    secrets:
+      splunkbase_user: ${{ secrets.SPLUNKBASE_USER }}
+      splunkbase_password: ${{ secrets.SPLUNKBASE_PASSWORD }}
+      semantic_release_pk: ${{ secrets.SEMANTIC_RELEASE_PK }}
+      slack_internal_token: ${{ secrets.SLACK_INTERNAL_TOKEN }}
+      slack_community_token: ${{ secrets.SLACK_COMMUNITY_TOKEN }}


### PR DESCRIPTION
Update call-publish.yml to pass new required secrets (slack_internal_token, slack_community_token) and remove deprecated release_queue_url.